### PR TITLE
feat: 添加哨兵信息接收和哨兵决策发送功能

### DIFF
--- a/include/standard_robot_pp_ros2/packet_typedef.hpp
+++ b/include/standard_robot_pp_ros2/packet_typedef.hpp
@@ -38,10 +38,10 @@ const uint8_t ID_RFID_STATUS = 0x0A;
 const uint8_t ID_ROBOT_STATUS = 0x0B;
 const uint8_t ID_JOINT_STATE = 0x0C;
 const uint8_t ID_BUFF = 0x0D;
-const uint8_t ID_SENTRY_INFO = 0x0E; 
+const uint8_t ID_SENTRY_INFO = 0x0E;
 // Send
 const uint8_t ID_ROBOT_CMD = 0x01;
-const uint8_t ID_SENTRY_CMD = 0x04; 
+const uint8_t ID_SENTRY_CMD = 0x04;
 const uint8_t DEBUG_PACKAGE_NUM = 10;
 const uint8_t DEBUG_PACKAGE_NAME_LEN = 10;
 
@@ -143,14 +143,14 @@ struct ReceiveEventData
     uint8_t overlapping_supply_zone : 1;
     uint8_t supply_zone : 1;
 
-    uint8_t small_energy : 2; //
-    uint8_t big_energy : 2; //
-    uint8_t reserved1 : 1; //
+    uint8_t small_energy : 2;  //
+    uint8_t big_energy : 2;    //
+    uint8_t reserved1 : 1;     //
 
     uint8_t central_highland : 2;
     uint8_t trapezoidal_highland : 2;
     uint8_t center_gain_zone : 2;
-    uint8_t reserved2 : 2; //
+    uint8_t reserved2 : 2;  //
 
   } __attribute__((packed)) data;
   uint16_t crc;
@@ -179,14 +179,14 @@ struct ReceiveAllRobotHpData
 
   struct
   {
-    uint16_t ally_1_robot_HP;      // 
-    uint16_t ally_2_robot_HP;      // 
-    uint16_t ally_3_robot_HP;      // 
-    uint16_t ally_4_robot_HP;      // 
-    uint16_t reserved;             // 
-    uint16_t ally_7_robot_HP;      // 
-    uint16_t ally_outpost_HP;      // 
-    uint16_t ally_base_HP;         // 
+    uint16_t ally_1_robot_HP;  //
+    uint16_t ally_2_robot_HP;  //
+    uint16_t ally_3_robot_HP;  //
+    uint16_t ally_4_robot_HP;  //
+    uint16_t reserved;         //
+    uint16_t ally_7_robot_HP;  //
+    uint16_t ally_outpost_HP;  //
+    uint16_t ally_base_HP;     //
   } __attribute__((packed)) data;
 
   uint16_t crc;
@@ -241,8 +241,8 @@ struct ReceiveGroundRobotPosition
     float standard_3_x;
     float standard_3_y;
 
-    float standard_4_x;//
-    float standard_4_y;//
+    float standard_4_x;  //
+    float standard_4_y;  //
 
     float reserved1;
     float reserved2;
@@ -336,7 +336,6 @@ struct ReceiveJointState
 // 机器人增益和底盘能量数据包
 struct ReceiveBuff
 {
-  
   HeaderFrame frame_header;
   uint32_t time_stamp;
 
@@ -367,8 +366,6 @@ struct ReceiveSentryInfo
 
   uint16_t crc;
 } __attribute__((packed));
-
-
 
 /********************************************************/
 /* Send data                                            */
@@ -418,7 +415,6 @@ struct SendRobotCmdData
   uint16_t checksum;
 } __attribute__((packed));
 
-
 // 哨兵自主决策指令数据包 (0x04 - 依据：表1-32)
 struct SendSentryCmdData
 {
@@ -432,8 +428,6 @@ struct SendSentryCmdData
 
   uint16_t checksum;
 } __attribute__((packed));
-
-
 
 /********************************************************/
 /* template                                             */

--- a/include/standard_robot_pp_ros2/packet_typedef.hpp
+++ b/include/standard_robot_pp_ros2/packet_typedef.hpp
@@ -38,9 +38,10 @@ const uint8_t ID_RFID_STATUS = 0x0A;
 const uint8_t ID_ROBOT_STATUS = 0x0B;
 const uint8_t ID_JOINT_STATE = 0x0C;
 const uint8_t ID_BUFF = 0x0D;
+const uint8_t ID_SENTRY_INFO = 0x0E; 
 // Send
 const uint8_t ID_ROBOT_CMD = 0x01;
-
+const uint8_t ID_SENTRY_CMD = 0x04; 
 const uint8_t DEBUG_PACKAGE_NUM = 10;
 const uint8_t DEBUG_PACKAGE_NAME_LEN = 10;
 
@@ -142,17 +143,15 @@ struct ReceiveEventData
     uint8_t overlapping_supply_zone : 1;
     uint8_t supply_zone : 1;
 
-    uint8_t small_energy : 1;
-    uint8_t big_energy : 1;
+    uint8_t small_energy : 2; //
+    uint8_t big_energy : 2; //
+    uint8_t reserved1 : 1; //
 
     uint8_t central_highland : 2;
-    uint8_t reserved1 : 1;
-
     uint8_t trapezoidal_highland : 2;
-
     uint8_t center_gain_zone : 2;
+    uint8_t reserved2 : 2; //
 
-    uint8_t reserved2 : 4;
   } __attribute__((packed)) data;
   uint16_t crc;
 } __attribute__((packed));
@@ -180,21 +179,14 @@ struct ReceiveAllRobotHpData
 
   struct
   {
-    uint16_t red_1_robot_hp;
-    uint16_t red_2_robot_hp;
-    uint16_t red_3_robot_hp;
-    uint16_t red_4_robot_hp;
-    uint16_t red_7_robot_hp;
-    uint16_t red_outpost_hp;
-    uint16_t red_base_hp;
-
-    uint16_t blue_1_robot_hp;
-    uint16_t blue_2_robot_hp;
-    uint16_t blue_3_robot_hp;
-    uint16_t blue_4_robot_hp;
-    uint16_t blue_7_robot_hp;
-    uint16_t blue_outpost_hp;
-    uint16_t blue_base_hp;
+    uint16_t ally_1_robot_HP;      // 
+    uint16_t ally_2_robot_HP;      // 
+    uint16_t ally_3_robot_HP;      // 
+    uint16_t ally_4_robot_HP;      // 
+    uint16_t reserved;             // 
+    uint16_t ally_7_robot_HP;      // 
+    uint16_t ally_outpost_HP;      // 
+    uint16_t ally_base_HP;         // 
   } __attribute__((packed)) data;
 
   uint16_t crc;
@@ -249,8 +241,8 @@ struct ReceiveGroundRobotPosition
     float standard_3_x;
     float standard_3_y;
 
-    float standard_4_x;
-    float standard_4_y;
+    float standard_4_x;//
+    float standard_4_y;//
 
     float reserved1;
     float reserved2;
@@ -344,13 +336,14 @@ struct ReceiveJointState
 // 机器人增益和底盘能量数据包
 struct ReceiveBuff
 {
+  
   HeaderFrame frame_header;
   uint32_t time_stamp;
 
   struct
   {
     uint8_t recovery_buff;
-    uint8_t cooling_buff;
+    uint16_t cooling_buff;  //
     uint8_t defence_buff;
     uint8_t vulnerability_buff;
     uint16_t attack_buff;
@@ -359,6 +352,24 @@ struct ReceiveBuff
 
   uint16_t crc;
 } __attribute__((packed));
+
+// 哨兵自主决策信息同步数据包 (0x0E - 依据：表1-22)
+struct ReceiveSentryInfo
+{
+  HeaderFrame frame_header;
+  uint32_t time_stamp;
+
+  struct
+  {
+    uint32_t sentry_info;    // bit 0-31
+    uint16_t sentry_info_2;  // bit 0-15
+  } __attribute__((packed)) data;
+
+  uint16_t crc;
+} __attribute__((packed));
+
+
+
 /********************************************************/
 /* Send data                                            */
 /********************************************************/
@@ -406,6 +417,23 @@ struct SendRobotCmdData
 
   uint16_t checksum;
 } __attribute__((packed));
+
+
+// 哨兵自主决策指令数据包 (0x04 - 依据：表1-32)
+struct SendSentryCmdData
+{
+  HeaderFrame frame_header;
+  uint32_t time_stamp;
+
+  struct
+  {
+    uint32_t sentry_cmd;  // bit 0-31
+  } __attribute__((packed)) data;
+
+  uint16_t checksum;
+} __attribute__((packed));
+
+
 
 /********************************************************/
 /* template                                             */

--- a/include/standard_robot_pp_ros2/standard_robot_pp_ros2.hpp
+++ b/include/standard_robot_pp_ros2/standard_robot_pp_ros2.hpp
@@ -26,14 +26,14 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "pb_rm_interfaces/msg/buff.hpp"
 #include "pb_rm_interfaces/msg/event_data.hpp"
-#include "pb_rm_interfaces/msg/sentry_info.hpp"      // add
-#include "pb_rm_interfaces/msg/sentry_cmd.hpp"       // add
 #include "pb_rm_interfaces/msg/game_robot_hp.hpp"
 #include "pb_rm_interfaces/msg/game_status.hpp"
 #include "pb_rm_interfaces/msg/ground_robot_position.hpp"
 #include "pb_rm_interfaces/msg/rfid_status.hpp"
 #include "pb_rm_interfaces/msg/robot_state_info.hpp"
 #include "pb_rm_interfaces/msg/robot_status.hpp"
+#include "pb_rm_interfaces/msg/sentry_cmd.hpp"   // add
+#include "pb_rm_interfaces/msg/sentry_info.hpp"  // add
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
@@ -79,14 +79,12 @@ private:
   rclcpp::Publisher<pb_rm_interfaces::msg::Buff>::SharedPtr buff_pub_;
   rclcpp::Publisher<pb_rm_interfaces::msg::SentryInfo>::SharedPtr sentry_info_pub_;  // add
 
-
   // Subscribe
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr cmd_gimbal_joint_sub_;
   rclcpp::Subscription<example_interfaces::msg::UInt8>::SharedPtr cmd_shoot_sub_;
   rclcpp::Subscription<auto_aim_interfaces::msg::Target>::SharedPtr cmd_tracking_sub_;
   rclcpp::Subscription<pb_rm_interfaces::msg::SentryCmd>::SharedPtr sentry_cmd_sub_;  // add
-
 
   RobotModels robot_models_;
   std::unordered_map<std::string, rclcpp::Publisher<example_interfaces::msg::Float64>::SharedPtr>
@@ -121,7 +119,7 @@ private:
   void cmdGimbalJointCallback(const sensor_msgs::msg::JointState::SharedPtr msg);
   void cmdShootCallback(const example_interfaces::msg::UInt8::SharedPtr msg);
   void visionTargetCallback(const auto_aim_interfaces::msg::Target::SharedPtr msg);
-  void sentryCmdCallback(const pb_rm_interfaces::msg::SentryCmd::SharedPtr msg); 
+  void sentryCmdCallback(const pb_rm_interfaces::msg::SentryCmd::SharedPtr msg);
   void setParam(const rclcpp::Parameter & param);
   bool getDetectColor(uint8_t robot_id, uint8_t & color);
   bool callTriggerService(const std::string & service_name);

--- a/include/standard_robot_pp_ros2/standard_robot_pp_ros2.hpp
+++ b/include/standard_robot_pp_ros2/standard_robot_pp_ros2.hpp
@@ -26,6 +26,8 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "pb_rm_interfaces/msg/buff.hpp"
 #include "pb_rm_interfaces/msg/event_data.hpp"
+#include "pb_rm_interfaces/msg/sentry_info.hpp"      // add
+#include "pb_rm_interfaces/msg/sentry_cmd.hpp"       // add
 #include "pb_rm_interfaces/msg/game_robot_hp.hpp"
 #include "pb_rm_interfaces/msg/game_status.hpp"
 #include "pb_rm_interfaces/msg/ground_robot_position.hpp"
@@ -75,18 +77,23 @@ private:
   rclcpp::Publisher<pb_rm_interfaces::msg::RobotStatus>::SharedPtr robot_status_pub_;
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
   rclcpp::Publisher<pb_rm_interfaces::msg::Buff>::SharedPtr buff_pub_;
+  rclcpp::Publisher<pb_rm_interfaces::msg::SentryInfo>::SharedPtr sentry_info_pub_;  // add
+
 
   // Subscribe
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr cmd_gimbal_joint_sub_;
   rclcpp::Subscription<example_interfaces::msg::UInt8>::SharedPtr cmd_shoot_sub_;
   rclcpp::Subscription<auto_aim_interfaces::msg::Target>::SharedPtr cmd_tracking_sub_;
+  rclcpp::Subscription<pb_rm_interfaces::msg::SentryCmd>::SharedPtr sentry_cmd_sub_;  // add
+
 
   RobotModels robot_models_;
   std::unordered_map<std::string, rclcpp::Publisher<example_interfaces::msg::Float64>::SharedPtr>
     debug_pub_map_;
 
   SendRobotCmdData send_robot_cmd_data_;
+  SendSentryCmdData send_sentry_cmd_data_;  // add
 
   void getParams();
   void createPublisher();
@@ -108,12 +115,13 @@ private:
   void publishRobotStatus(ReceiveRobotStatus & data);
   void publishJointState(ReceiveJointState & data);
   void publishBuff(ReceiveBuff & data);
+  void publishSentryInfo(ReceiveSentryInfo & data);  // add
 
   void cmdVelCallback(const geometry_msgs::msg::Twist::SharedPtr msg);
   void cmdGimbalJointCallback(const sensor_msgs::msg::JointState::SharedPtr msg);
   void cmdShootCallback(const example_interfaces::msg::UInt8::SharedPtr msg);
   void visionTargetCallback(const auto_aim_interfaces::msg::Target::SharedPtr msg);
-
+  void sentryCmdCallback(const pb_rm_interfaces::msg::SentryCmd::SharedPtr msg); 
   void setParam(const rclcpp::Parameter & param);
   bool getDetectColor(uint8_t robot_id, uint8_t & color);
   bool callTriggerService(const std::string & service_name);

--- a/src/standard_robot_pp_ros2.cpp
+++ b/src/standard_robot_pp_ros2.cpp
@@ -96,6 +96,8 @@ void StandardRobotPpRos2Node::createPublisher()
   robot_status_pub_ =
     this->create_publisher<pb_rm_interfaces::msg::RobotStatus>("referee/robot_status", 10);
   buff_pub_ = this->create_publisher<pb_rm_interfaces::msg::Buff>("referee/buff", 10);
+  sentry_info_pub_ =
+    this->create_publisher<pb_rm_interfaces::msg::SentryInfo>("referee/sentry_info", 10);
 }
 
 void StandardRobotPpRos2Node::createNewDebugPublisher(const std::string & name)
@@ -122,6 +124,10 @@ void StandardRobotPpRos2Node::createSubscription()
   cmd_tracking_sub_ = this->create_subscription<auto_aim_interfaces::msg::Target>(
     "tracker/target", 10,
     std::bind(&StandardRobotPpRos2Node::visionTargetCallback, this, std::placeholders::_1));
+  
+  sentry_cmd_sub_ = this->create_subscription<pb_rm_interfaces::msg::SentryCmd>(
+    "sentry_cmd", 10,
+    std::bind(&StandardRobotPpRos2Node::sentryCmdCallback, this, std::placeholders::_1));
 }
 
 void StandardRobotPpRos2Node::getParams()
@@ -391,6 +397,10 @@ void StandardRobotPpRos2Node::receiveData()
           ReceiveBuff buff = fromVector<ReceiveBuff>(data_buf);
           publishBuff(buff);
         } break;
+        case ID_SENTRY_INFO: {
+          ReceiveSentryInfo sentry_info = fromVector<ReceiveSentryInfo>(data_buf);
+          publishSentryInfo(sentry_info);
+        } break;
         default: {
           RCLCPP_WARN(get_logger(), "Invalid id: %d", header_frame.id);
         } break;
@@ -501,28 +511,22 @@ void StandardRobotPpRos2Node::publishEventData(ReceiveEventData & event_data)
   event_data_pub_->publish(msg);
 }
 
+//add
 void StandardRobotPpRos2Node::publishAllRobotHp(ReceiveAllRobotHpData & all_robot_hp)
 {
   pb_rm_interfaces::msg::GameRobotHP msg;
 
-  msg.red_1_robot_hp = all_robot_hp.data.red_1_robot_hp;
-  msg.red_2_robot_hp = all_robot_hp.data.red_2_robot_hp;
-  msg.red_3_robot_hp = all_robot_hp.data.red_3_robot_hp;
-  msg.red_4_robot_hp = all_robot_hp.data.red_4_robot_hp;
-  msg.red_7_robot_hp = all_robot_hp.data.red_7_robot_hp;
-  msg.red_outpost_hp = all_robot_hp.data.red_outpost_hp;
-  msg.red_base_hp = all_robot_hp.data.red_base_hp;
-
-  msg.blue_1_robot_hp = all_robot_hp.data.blue_1_robot_hp;
-  msg.blue_2_robot_hp = all_robot_hp.data.blue_2_robot_hp;
-  msg.blue_3_robot_hp = all_robot_hp.data.blue_3_robot_hp;
-  msg.blue_4_robot_hp = all_robot_hp.data.blue_4_robot_hp;
-  msg.blue_7_robot_hp = all_robot_hp.data.blue_7_robot_hp;
-  msg.blue_outpost_hp = all_robot_hp.data.blue_outpost_hp;
-  msg.blue_base_hp = all_robot_hp.data.blue_base_hp;
+  msg.ally_1_robot_hp = all_robot_hp.data.ally_1_robot_HP;
+  msg.ally_2_robot_hp = all_robot_hp.data.ally_2_robot_HP;
+  msg.ally_3_robot_hp = all_robot_hp.data.ally_3_robot_HP;
+  msg.ally_4_robot_hp = all_robot_hp.data.ally_4_robot_HP;
+  msg.ally_7_robot_hp = all_robot_hp.data.ally_7_robot_HP;
+  msg.ally_outpost_hp = all_robot_hp.data.ally_outpost_HP;
+  msg.ally_base_hp = all_robot_hp.data.ally_base_HP;
 
   all_robot_hp_pub_->publish(msg);
 }
+
 
 void StandardRobotPpRos2Node::publishGameStatus(ReceiveGameStatusData & game_status)
 {
@@ -569,17 +573,17 @@ void StandardRobotPpRos2Node::publishGroundRobotPosition(
 {
   pb_rm_interfaces::msg::GroundRobotPosition msg;
 
-  msg.hero_position.x = ground_robot_position.data.hero_x;
-  msg.hero_position.y = ground_robot_position.data.hero_y;
+  msg.hero_position_x = ground_robot_position.data.hero_x;
+  msg.hero_position_y = ground_robot_position.data.hero_y;
 
-  msg.engineer_position.x = ground_robot_position.data.engineer_x;
-  msg.engineer_position.y = ground_robot_position.data.engineer_y;
+  msg.engineer_position_x = ground_robot_position.data.engineer_x;
+  msg.engineer_position_y = ground_robot_position.data.engineer_y;
 
-  msg.standard_3_position.x = ground_robot_position.data.standard_3_x;
-  msg.standard_3_position.y = ground_robot_position.data.standard_3_y;
+  msg.standard_3_position_x = ground_robot_position.data.standard_3_x;
+  msg.standard_3_position_y = ground_robot_position.data.standard_3_y;
 
-  msg.standard_4_position.x = ground_robot_position.data.standard_4_x;
-  msg.standard_4_position.y = ground_robot_position.data.standard_4_y;
+  msg.standard_4_position_x = ground_robot_position.data.standard_4_x;
+  msg.standard_4_position_y = ground_robot_position.data.standard_4_y;
 
   ground_robot_position_pub_->publish(msg);
 }
@@ -679,6 +683,26 @@ void StandardRobotPpRos2Node::publishBuff(ReceiveBuff & buff)
   buff_pub_->publish(msg);
 }
 
+void StandardRobotPpRos2Node::publishSentryInfo(ReceiveSentryInfo & sentry_info)
+{
+  pb_rm_interfaces::msg::SentryInfo msg;
+
+  // 解析 sentry_info (uint32, bit 0-31)
+  msg.exchanged_projectile_allowance = sentry_info.data.sentry_info & 0x7FF;
+  msg.remote_projectile_exchange_count = (sentry_info.data.sentry_info >> 11) & 0xF;
+  msg.remote_hp_exchange_count = (sentry_info.data.sentry_info >> 15) & 0xF;
+  msg.can_free_respawn = (sentry_info.data.sentry_info >> 19) & 0x1;
+  msg.can_pay_respawn = (sentry_info.data.sentry_info >> 20) & 0x1;
+  msg.respawn_gold_cost = (sentry_info.data.sentry_info >> 21) & 0x3FF;
+
+  // 解析 sentry_info_2 (uint16, bit 0-15)
+  msg.current_posture = (sentry_info.data.sentry_info_2 >> 12) & 0x3;
+  msg.can_activate_rune = (sentry_info.data.sentry_info_2 >> 14) & 0x1;
+
+  sentry_info_pub_->publish(msg);
+}
+
+
 /********************************************************/
 /* Send data                                            */
 /********************************************************/
@@ -696,6 +720,17 @@ void StandardRobotPpRos2Node::sendData()
   crc8::append_CRC8_check_sum(
     reinterpret_cast<uint8_t *>(&send_robot_cmd_data_), sizeof(HeaderFrame));
 
+
+  // 初始化哨兵指令数据包
+  send_sentry_cmd_data_.frame_header.sof = SOF_SEND;
+  send_sentry_cmd_data_.frame_header.id = ID_SENTRY_CMD;
+  send_sentry_cmd_data_.frame_header.len = sizeof(SendSentryCmdData) - 6;
+  send_sentry_cmd_data_.data.sentry_cmd = 0;
+  crc8::append_CRC8_check_sum(
+    reinterpret_cast<uint8_t *>(&send_sentry_cmd_data_), sizeof(HeaderFrame));
+
+
+
   int retry_count = 0;
 
   while (rclcpp::ok()) {
@@ -711,9 +746,15 @@ void StandardRobotPpRos2Node::sendData()
       crc16::append_CRC16_check_sum(
         reinterpret_cast<uint8_t *>(&send_robot_cmd_data_), sizeof(SendRobotCmdData));
 
-      // 发送数据
+     // 发送机器人控制数据
       std::vector<uint8_t> send_data = toVector(send_robot_cmd_data_);
       serial_driver_->port()->send(send_data);
+
+    // 发送哨兵指令数据
+      crc16::append_CRC16_check_sum(
+        reinterpret_cast<uint8_t *>(&send_sentry_cmd_data_), sizeof(SendSentryCmdData));
+      std::vector<uint8_t> sentry_cmd_data = toVector(send_sentry_cmd_data_);
+      serial_driver_->port()->send(sentry_cmd_data);
     } catch (const std::exception & ex) {
       RCLCPP_ERROR(get_logger(), "Error sending data: %s", ex.what());
       is_usb_ok_ = false;
@@ -757,6 +798,23 @@ void StandardRobotPpRos2Node::cmdShootCallback(const example_interfaces::msg::UI
 {
   send_robot_cmd_data_.data.shoot.fric_on = true;
   send_robot_cmd_data_.data.shoot.fire = msg->data;
+}
+
+
+void StandardRobotPpRos2Node::sentryCmdCallback(const pb_rm_interfaces::msg::SentryCmd::SharedPtr msg)
+{
+  // sentry_cmd (uint32, bit 0-31)
+  send_sentry_cmd_data_.data.sentry_cmd = 0;
+
+  send_sentry_cmd_data_.data.sentry_cmd |= (msg->confirm_respawn & 0x1);
+  send_sentry_cmd_data_.data.sentry_cmd |= ((msg->confirm_pay_respawn & 0x1) << 1);
+  send_sentry_cmd_data_.data.sentry_cmd |= ((msg->projectile_allowance_to_exchange & 0x7FF) << 2);
+  send_sentry_cmd_data_.data.sentry_cmd |= ((msg->remote_projectile_request_count & 0xF) << 13);
+  send_sentry_cmd_data_.data.sentry_cmd |= ((msg->remote_hp_request_count & 0xF) << 17);
+  send_sentry_cmd_data_.data.sentry_cmd |= ((msg->posture_command & 0x3) << 21);
+  send_sentry_cmd_data_.data.sentry_cmd |= ((msg->activate_rune & 0x1) << 23);
+
+  RCLCPP_INFO(get_logger(), "Sentry cmd: 0x%08X", send_sentry_cmd_data_.data.sentry_cmd);
 }
 
 void StandardRobotPpRos2Node::setParam(const rclcpp::Parameter & param)

--- a/src/standard_robot_pp_ros2.cpp
+++ b/src/standard_robot_pp_ros2.cpp
@@ -124,7 +124,7 @@ void StandardRobotPpRos2Node::createSubscription()
   cmd_tracking_sub_ = this->create_subscription<auto_aim_interfaces::msg::Target>(
     "tracker/target", 10,
     std::bind(&StandardRobotPpRos2Node::visionTargetCallback, this, std::placeholders::_1));
-  
+
   sentry_cmd_sub_ = this->create_subscription<pb_rm_interfaces::msg::SentryCmd>(
     "sentry_cmd", 10,
     std::bind(&StandardRobotPpRos2Node::sentryCmdCallback, this, std::placeholders::_1));
@@ -527,7 +527,6 @@ void StandardRobotPpRos2Node::publishAllRobotHp(ReceiveAllRobotHpData & all_robo
   all_robot_hp_pub_->publish(msg);
 }
 
-
 void StandardRobotPpRos2Node::publishGameStatus(ReceiveGameStatusData & game_status)
 {
   pb_rm_interfaces::msg::GameStatus msg;
@@ -702,7 +701,6 @@ void StandardRobotPpRos2Node::publishSentryInfo(ReceiveSentryInfo & sentry_info)
   sentry_info_pub_->publish(msg);
 }
 
-
 /********************************************************/
 /* Send data                                            */
 /********************************************************/
@@ -720,7 +718,6 @@ void StandardRobotPpRos2Node::sendData()
   crc8::append_CRC8_check_sum(
     reinterpret_cast<uint8_t *>(&send_robot_cmd_data_), sizeof(HeaderFrame));
 
-
   // 初始化哨兵指令数据包
   send_sentry_cmd_data_.frame_header.sof = SOF_SEND;
   send_sentry_cmd_data_.frame_header.id = ID_SENTRY_CMD;
@@ -728,8 +725,6 @@ void StandardRobotPpRos2Node::sendData()
   send_sentry_cmd_data_.data.sentry_cmd = 0;
   crc8::append_CRC8_check_sum(
     reinterpret_cast<uint8_t *>(&send_sentry_cmd_data_), sizeof(HeaderFrame));
-
-
 
   int retry_count = 0;
 
@@ -746,11 +741,11 @@ void StandardRobotPpRos2Node::sendData()
       crc16::append_CRC16_check_sum(
         reinterpret_cast<uint8_t *>(&send_robot_cmd_data_), sizeof(SendRobotCmdData));
 
-     // 发送机器人控制数据
+      // 发送机器人控制数据
       std::vector<uint8_t> send_data = toVector(send_robot_cmd_data_);
       serial_driver_->port()->send(send_data);
 
-    // 发送哨兵指令数据
+      // 发送哨兵指令数据
       crc16::append_CRC16_check_sum(
         reinterpret_cast<uint8_t *>(&send_sentry_cmd_data_), sizeof(SendSentryCmdData));
       std::vector<uint8_t> sentry_cmd_data = toVector(send_sentry_cmd_data_);
@@ -800,8 +795,8 @@ void StandardRobotPpRos2Node::cmdShootCallback(const example_interfaces::msg::UI
   send_robot_cmd_data_.data.shoot.fire = msg->data;
 }
 
-
-void StandardRobotPpRos2Node::sentryCmdCallback(const pb_rm_interfaces::msg::SentryCmd::SharedPtr msg)
+void StandardRobotPpRos2Node::sentryCmdCallback(
+  const pb_rm_interfaces::msg::SentryCmd::SharedPtr msg)
 {
   // sentry_cmd (uint32, bit 0-31)
   send_sentry_cmd_data_.data.sentry_cmd = 0;


### PR DESCRIPTION
### Summary
新增哨兵相关串口通信能力（参考 RoboMaster 2026 协议 V1.1.0）：
- 新增接收包：`ID_SENTRY_INFO (0x0E)` → 发布 `referee/sentry_info`
- 新增发送包：`ID_SENTRY_CMD (0x04)` → 订阅 `sentry_cmd` 并周期下发

### Changes
- `packet_typedef.hpp`
  - 新增 `ID_SENTRY_INFO (0x0E)`、`ID_SENTRY_CMD (0x04)`
  - 新增 `ReceiveSentryInfo`、`SendSentryCmdData`
- `standard_robot_pp_ros2.hpp/.cpp`
  - 新增 publisher：`referee/sentry_info`
  - 新增 subscription：`sentry_cmd`
  - 新增 `publishSentryInfo()`、`sentryCmdCallback()`，支持位域解析与打包发送

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sentry robot information publishing and command subscription capabilities
  * Enabled integrated Sentry robot control support

* **Improvements**
  * Restructured robot HP reporting with improved naming conventions
  * Extended cooling buffer data field size for enhanced precision
  * Refined event data bitfield allocation for optimized memory usage

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->